### PR TITLE
Added `:shared` to couch potato volume.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
             - PGID=${PGID}
         volumes:
             - './couchpotato:/config'
-            - './content/completed:/downloads'
+            - './content/completed:/downloads:shared'
             - './content/movies:/movies'
             - '/etc/localtime:/etc/localtime:ro'
 


### PR DESCRIPTION
:shared enables the containers to view mounts from the host machine. (usb, cifs, etc)